### PR TITLE
Migrate CMS from Netlify Identity to GitHub OAuth

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,8 +1,11 @@
 backend:
-  name: git-gateway
+  name: github
+  repo: 7mxd/7mxd.github.io
   branch: main
+  base_url: https://7mxd-portfolio.up.railway.app
+  auth_endpoint: /auth
 
-site_url: https://7mxd-auth.netlify.app
+site_url: https://7mxd.github.io
 
 media_folder: "assets"
 public_folder: "assets"

--- a/admin/index.html
+++ b/admin/index.html
@@ -5,15 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="robots" content="noindex" />
   <title>Content Manager | Ahmed's Portfolio</title>
-  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-  <script>
-    // Initialize Netlify Identity with the correct Netlify site URL
-    if (window.netlifyIdentity) {
-      window.netlifyIdentity.init({
-        APIUrl: "https://7mxd-auth.netlify.app/.netlify/identity"
-      });
-    }
-  </script>
 </head>
 <body>
   <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>


### PR DESCRIPTION
Replace Netlify Identity authentication with GitHub OAuth backend deployed on Railway.

Changes:
- Update backend from git-gateway to github with Railway OAuth server
- Configure base_url to point to Railway deployment (7mxd-portfolio.up.railway.app)
- Remove Netlify Identity widget and initialization scripts
- Update site_url to GitHub Pages domain

This enables authentication through the custom OAuth backend server, eliminating dependency on Netlify's managed identity service.