### PR TITLE
Fix Railway 502 error by binding to 0.0.0.0

### DIFF
--- a/oauth-backend/server.js
+++ b/oauth-backend/server.js
@@ -308,7 +308,7 @@ app.use((err, req, res, next) => {
 });
 
 // Start server
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('🚀 Decap CMS OAuth Backend Server');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');


### PR DESCRIPTION
Update Express server to bind to 0.0.0.0 instead of default localhost. This is required for Railway to properly route external traffic to the containerized application. Without this, Railway's health checks fail and the service is terminated with SIGTERM.

Changes:
- app.listen(PORT, '0.0.0.0', ...) ensures the server is accessible from outside the container on all network interfaces