### PR TITLE
Fix OAuth token passing to Decap CMS

### DIFF
--- a/oauth-backend/server.js
+++ b/oauth-backend/server.js
@@ -152,9 +152,13 @@ app.get('/callback', async (req, res) => {
         <script>
           (function() {
             if (window.opener) {
+              const data = {
+                token: '${access_token}',
+                provider: 'github'
+              };
               window.opener.postMessage(
-                'authorization:github:success:{"token":"${access_token}","provider":"github"}',
-                '*'
+                'authorization:github:success:' + JSON.stringify(data),
+                'https://7mxd.github.io'
               );
               setTimeout(function() { window.close(); }, 1000);
             }
@@ -282,9 +286,13 @@ app.get('/success', (req, res) => {
       <script>
         (function() {
           if (window.opener) {
+            const data = {
+              token: '${token}',
+              provider: 'github'
+            };
             window.opener.postMessage(
-              'authorization:github:success:{"token":"${token}","provider":"github"}',
-              '*'
+              'authorization:github:success:' + JSON.stringify(data),
+              'https://7mxd.github.io'
             );
             window.close();
           }


### PR DESCRIPTION
Fix postMessage implementation to properly pass the access token from the OAuth callback to the CMS. The previous implementation had the token variable inside a single-quoted string within a template literal, preventing proper interpolation.

Changes:
- Use JSON.stringify() to properly construct the message payload
- Change target origin from '*' to specific 'https://7mxd.github.io' for security
- Apply fix to both /callback and /success endpoints
- Token is now correctly passed to window.opener for CMS authentication

This resolves the issue where the popup closes without logging into the CMS.