### PR TITLE
Fix skip link appearing on mobile swipe gestures

### DIFF
--- a/script.js
+++ b/script.js
@@ -755,9 +755,43 @@ function setupSmoothScrolling() {
 }
 
 /**
+ * Setup keyboard navigation detection for skip link
+ * Only shows skip link when user is actively using keyboard navigation
+ */
+function setupKeyboardDetection() {
+    const html = document.documentElement;
+
+    // Detect keyboard navigation (Tab key)
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Tab') {
+            html.classList.add('using-keyboard');
+        }
+    }, { capture: true });
+
+    // Detect mouse/touch - disable keyboard mode
+    document.addEventListener('mousedown', () => {
+        html.classList.remove('using-keyboard');
+    }, { capture: true });
+
+    document.addEventListener('touchstart', () => {
+        html.classList.remove('using-keyboard');
+    }, { capture: true, passive: true });
+
+    // Also handle pointer events for hybrid devices
+    document.addEventListener('pointerdown', (e) => {
+        if (e.pointerType !== 'keyboard') {
+            html.classList.remove('using-keyboard');
+        }
+    }, { capture: true });
+}
+
+/**
  * Main initialization
  */
 document.addEventListener('DOMContentLoaded', async () => {
+    // Setup keyboard detection first (for skip link)
+    setupKeyboardDetection();
+
     // Setup theme toggle first (before content loads)
     const themeState = setupThemeToggle();
 

--- a/style.css
+++ b/style.css
@@ -38,30 +38,37 @@ body * {
     clip-path: inset(50%);
     white-space: nowrap;
     border: 0;
+    /* Prevent any touch interaction */
+    pointer-events: none;
+    /* Disable tap highlight on iOS */
+    -webkit-tap-highlight-color: transparent;
     /* Styling for when visible */
     background: var(--secondary);
     color: white;
     font-weight: 600;
     text-decoration: none;
     z-index: 10000;
+}
 
-    &:focus-visible {
-        /* Restore visibility on keyboard focus */
-        position: fixed;
-        top: 0;
-        left: 50%;
-        transform: translateX(-50%);
-        width: auto;
-        height: auto;
-        padding: 12px 24px;
-        margin: 0;
-        overflow: visible;
-        clip: auto;
-        clip-path: none;
-        white-space: normal;
-        border-radius: 0 0 8px 8px;
-        box-shadow: 0 4px 12px rgba(33, 158, 188, 0.3);
-    }
+/* Only show skip link when:
+   1. User is navigating with keyboard (html.using-keyboard)
+   2. AND the link is focused */
+html.using-keyboard .skip-link:focus {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: auto;
+    height: auto;
+    padding: 12px 24px;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    clip-path: none;
+    white-space: normal;
+    border-radius: 0 0 8px 8px;
+    box-shadow: 0 4px 12px rgba(33, 158, 188, 0.3);
+    pointer-events: auto;
 }
 
 /* Screen reader only text */


### PR DESCRIPTION
Root cause: Safari/iOS triggers focus events during scroll restoration, touch interactions, and momentum scrolling. CSS :focus-visible alone is not reliable on Safari.

Solution: JavaScript-based keyboard detection
- Add 'using-keyboard' class to <html> when Tab key is pressed
- Remove class on any mouse/touch/pointer interaction
- Skip link only visible when BOTH class is present AND link is focused

CSS changes:
- Add pointer-events: none to prevent touch interaction
- Add -webkit-tap-highlight-color: transparent for iOS
- Replace :focus-visible with .using-keyboard :focus selector

This ensures the skip link ONLY appears during intentional keyboard navigation, never during touch scrolling or swipe gestures.